### PR TITLE
applications: nrf5340_audio: Ignore -EALREADY error when play/pause

### DIFF
--- a/applications/nrf5340_audio/src/audio/streamctrl.c
+++ b/applications/nrf5340_audio/src/audio/streamctrl.c
@@ -524,7 +524,7 @@ static void content_control_msg_sub_thread(void)
 		switch (event) {
 		case MEDIA_PLAY:
 			ret = le_audio_play();
-			if (ret) {
+			if (ret && (ret != -EALREADY)) {
 				LOG_ERR("Failed to play: %d", ret);
 			}
 
@@ -532,7 +532,7 @@ static void content_control_msg_sub_thread(void)
 
 		case MEDIA_PAUSE:
 			ret = le_audio_pause();
-			if (ret) {
+			if (ret && (ret != -EALREADY)) {
 				LOG_ERR("Failed to pause: %d", ret);
 			}
 


### PR DESCRIPTION
- If trying to play/pause too fast, le_audio will return -EALREADY
- This should not be printed as an error