### PR TITLE
applications: nrf5340_audio: Fix two nightly tests

### DIFF
--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/broadcast/broadcast_sink.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/broadcast/broadcast_sink.c
@@ -478,6 +478,11 @@ int broadcast_sink_pa_sync_set(struct bt_le_per_adv_sync *pa_sync, uint32_t broa
 		}
 	}
 
+	/* If broadcast_sink was not in an active stream we still need to clean it up */
+	if (broadcast_sink != NULL) {
+		broadcast_sink_cleanup();
+	}
+
 	ret = bt_bap_broadcast_sink_create(pa_sync, broadcast_id, &broadcast_sink);
 	if (ret) {
 		LOG_WRN("Failed to create sink: %d", ret);

--- a/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_client.c
+++ b/applications/nrf5340_audio/src/bluetooth/bt_stream/unicast/unicast_client.c
@@ -704,6 +704,7 @@ static void discover_cb(struct bt_conn *conn, int err, enum bt_audio_dir dir)
 			/* NOTE: The string below is used by the Nordic CI system */
 			LOG_WRN("No valid codec capability found for %s headset sink",
 				headsets[channel_index].ch_name);
+			headsets[channel_index].sink_ep = NULL;
 		}
 	} else if (dir == BT_AUDIO_DIR_SOURCE) {
 		if (valid_codec_cap_check(headsets[channel_index].source_codec_cap,
@@ -720,6 +721,7 @@ static void discover_cb(struct bt_conn *conn, int err, enum bt_audio_dir dir)
 		} else {
 			LOG_WRN("No valid codec capability found for %s headset source",
 				headsets[channel_index].ch_name);
+			headsets[channel_index].source_ep = NULL;
 		}
 	}
 


### PR DESCRIPTION
- Reject headset ep with unmatching capability in CIS
- Rescan for broadcaster if mismatch in sink pointers